### PR TITLE
Add installable bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "nummerino",
-  "private": true,
+  "name": "@carlotrimarchi/nummerino",
   "version": "0.2.0",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@carlotrimarchi/nummerino",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
+  "bin": {
+    "nummerino": "./dist/cli/cli.js"
+  },
   "scripts": {
+    "prepare": "npm run build:cli",
+    "build:cli": "tsc -p tsconfig.cli.json",
     "cli": "npx --silent tsx src/cli/cli.ts",
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,10 +1,12 @@
-import { numberToText } from "../core/numberToText/numberToText";
+#!/usr/bin/env node
+
+import { numberToText } from "../core/numberToText/numberToText.js";
 
 const input = process.argv[2];
 const number = Number(input);
 
 if (!input || isNaN(number)) {
-	console.error("Usage: npm run cli -- <number>");
+	console.error("Usage: nummerino <number>");
 	process.exit(1);
 }
 

--- a/src/core/numberToText/numberToText.ts
+++ b/src/core/numberToText/numberToText.ts
@@ -1,4 +1,4 @@
-import { ones, teens, tens, scales } from "./data";
+import { ones, teens, tens, scales } from "./data.js";
 
 /**
  * Decomposes a number into its place values, from smallest 

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"outDir": "./dist",
+		"strict": true,
+		"types": ["node"]
+	},
+	"include": ["src/cli", "src/core"],
+	"exclude": ["src/core/**/*.test.ts"]
+}


### PR DESCRIPTION
The CLI is now installable globally via npm:

```bash
npm install -g @carlotrimarchi/nummerino
```

Usage:

```bash
nummerino <number>
```

## Changes:

- Added bin field to package.json pointing to ./dist/cli/cli.js
- Added build:cli script using a dedicated tsconfig.cli.json with NodeNext module resolution
- Added prepare script to automatically build the CLI on install
- Added shebang to cli.ts
- Updated import paths to use .js extensions as required by NodeNext
- Removed private: true to allow future npm publishing
- Updated error message to reflect the new command name

Closes #5 