### PR TITLE
chore: add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main, chore/github-pages-deploy]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist/web
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import "./App.css";
 import PageHeader from "./components/PageHeader.js";
 import NumberToSpelling from "./components/NumberToSpelling.js";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
 		environment: "jsdom",
 		setupFiles: "./src/setupTests.ts",
 	},
+	build: {
+		outDir: "dist/web",
+	},
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 		environment: "jsdom",
 		setupFiles: "./src/setupTests.ts",
 	},
+	base: "/nummerino/",
 	build: {
 		outDir: "dist/web",
 	},


### PR DESCRIPTION
- add GitHub Actions workflow to build and deploy the web app to GitHub Pages
- configure Vite output to `dist/web/` to avoid conflicts with CLI build
- set base path to `/nummerino/` for correct asset resolution