### PR TITLE
feat: add joined/splitted spelling formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-16
+
+### Added
+
+- Numbers can now be expressed in two formats:
+	- joined: e.g. `einhundertdreiundzwanzig`, which is the linguistically correct German form, and 
+	- splitted: e.g. `ein hundert drei und zwanzig`, which is more readable and intended for future text-to-speech use
+- CLI outputs the joined form by default
+- `--splitted` flag to output the splitted form instead
+
+### Changed
+
+- `numberToText` now returns an object `{ joined, splitted }` instead of a string
+
 ## [0.3.0] - 2026-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,14 +12,22 @@ npm install -g @carlotrimarchi/nummerino
 
 ### Run
 ```bash
-nummerino <number>
+nummerino <number> [--splitted]
 ```
 
 ## Example
 
 ```bash
 nummerino 123
+# einhundertdreiundzwanzig
+
+nummerino 1234567
+# eine million zweihundertvierunddreißigtausendfünfhundertsiebenundsechzig
+
+nummerino 123 --splitted
 # ein hundert drei und zwanzig
+
+
 ```
 
 ## Roadmap
@@ -32,4 +40,4 @@ nummerino 123
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md) for release history.
+See [CHANGELOG.md](https://github.com/carlotrimarchi/nummerino/blob/main/CHANGELOG.md) for release history.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carlotrimarchi/nummerino",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@carlotrimarchi/nummerino",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@fontsource-variable/figtree": "^5.2.10",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
+    "test:core": "vitest src/core",
     "test:run": "vitest run"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carlotrimarchi/nummerino",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -2,12 +2,15 @@
 
 import { numberToText } from "../core/numberToText/numberToText.js";
 
-const input = process.argv[2];
+const args = process.argv.slice(2);
+const splitted = args.includes("--splitted");
+const input = args.find((a) => !a.startsWith("--"));
 const number = Number(input);
 
 if (!input || isNaN(number)) {
-	console.error("Usage: nummerino <number>");
+	console.error("Usage: nummerino <number> [--splitted]");
 	process.exit(1);
 }
 
-console.log(numberToText(number));
+const result = numberToText(number);
+console.log(splitted ? result.splitted : result.joined);

--- a/src/core/numberToText/numberToText.test.ts
+++ b/src/core/numberToText/numberToText.test.ts
@@ -93,111 +93,138 @@ describe("groupByScale", () => {
 });
 
 describe("scaledValuesToWords", () => {
-	const cases: [[number, number[]][], string][] = [
-		[[[1_000, [2_000]]], "zwei tausend"],
-		[[[1_000, [10_000, 9_000]]], "neunzehn tausend"],
-		[[[1_000, [20_000, 9_000]]], "neun und zwanzig tausend"],
-		[
-			[[1_000, [100_000, 20_000, 9_000]]],
-			"ein hundert neun und zwanzig tausend",
-		],
-		[[[1_000_000, [1_000_000]]], "eine million"],
-		[[[1_000_000, [2_000_000]]], "zwei millionen"],
-		[[[1_000_000_000, [1_000_000_000]]], "eine milliarde"],
-		[[[1_000_000_000, [3_000_000_000]]], "drei milliarden"],
-	];
-	it.each(cases)("converts %o to %s", (input, expected) => {
-		expect(scaledValuesToWords(input)).toBe(expected);
+	describe("splitted (default)", () => {
+		const cases: [[number, number[]][], string][] = [
+			[[[1_000, [2_000]]], "zwei tausend"],
+			[[[1_000, [10_000, 9_000]]], "neunzehn tausend"],
+			[[[1_000, [20_000, 9_000]]], "neun und zwanzig tausend"],
+			[
+				[[1_000, [100_000, 20_000, 9_000]]],
+				"ein hundert neun und zwanzig tausend",
+			],
+			[[[1_000_000, [1_000_000]]], "eine million"],
+			[[[1_000_000, [2_000_000]]], "zwei millionen"],
+			[[[1_000_000_000, [1_000_000_000]]], "eine milliarde"],
+			[[[1_000_000_000, [3_000_000_000]]], "drei milliarden"],
+		];
+		it.each(cases)("converts %o to %s", (input, expected) => {
+			expect(scaledValuesToWords(input)).toBe(expected);
+		});
+	});
+
+	describe("joined", () => {
+		const cases: [[number, number[]][], string][] = [
+			[[[1_000, [2_000]]], "zweitausend"],
+			[[[1_000, [10_000, 9_000]]], "neunzehntausend"],
+			[[[1_000, [20_000, 9_000]]], "neunundzwanzigtausend"],
+			[
+				[[1_000, [100_000, 20_000, 9_000]]],
+				"einhundertneunundzwanzigtausend",
+			],
+			[[[1_000_000, [1_000_000]]], "eine million"],
+			[[[1_000_000, [2_000_000]]], "zwei millionen"],
+		];
+		it.each(cases)("converts %o to %s", (input, expected) => {
+			expect(scaledValuesToWords(input, "joined")).toBe(expected);
+		});
 	});
 });
 
 describe("unscaledValuesToWords", () => {
-	const cases: [number[], string][] = [
-		[[1], "ein"],
-		[[2], "zwei"],
-		[[10], "zehn"],
-		[[12], "zwölf"],
-		[[19], "neunzehn"],
-		[[20], "zwanzig"],
-		[[3, 20], "drei und zwanzig"],
-		[[3, 30], "drei und dreißig"],
-		[[9, 90], "neun und neunzig"],
-	];
+	describe("splitted (default)", () => {
+		const cases: [number[], string][] = [
+			[[1], "ein"],
+			[[2], "zwei"],
+			[[10], "zehn"],
+			[[12], "zwölf"],
+			[[19], "neunzehn"],
+			[[20], "zwanzig"],
+			[[3, 20], "drei und zwanzig"],
+			[[3, 30], "drei und dreißig"],
+			[[9, 90], "neun und neunzig"],
+		];
+		it.each(cases)("converts %j to %s", (input, expected) => {
+			expect(unscaledValuesToWords(input)).toBe(expected);
+		});
+	});
 
-	it.each(cases)("converts %i to %s", (input, expected) => {
-		expect(unscaledValuesToWords(input)).toBe(expected);
+	describe("joined", () => {
+		const cases: [number[], string][] = [
+			[[1], "ein"],
+			[[20], "zwanzig"],
+			[[3, 20], "dreiundzwanzig"],
+			[[3, 30], "dreiunddreißig"],
+			[[9, 90], "neunundneunzig"],
+		];
+		it.each(cases)("converts %j to %s", (input, expected) => {
+			expect(unscaledValuesToWords(input, "joined")).toBe(expected);
+		});
 	});
 });
 
 describe("numberToText", () => {
-	describe("single digit numbers", () => {
-		it("converts 0 to null (special case)", () => {
-			expect(numberToText(0)).toBe("null");
-		});
-		it("converts 1 to eins (special case)", () => {
-			expect(numberToText(1)).toBe("eins");
-		});
+	it("converts 0 (special case)", () => {
+		expect(numberToText(0)).toEqual({ joined: "null", splitted: "null" });
+	});
+	it("converts 1 (special case)", () => {
+		expect(numberToText(1)).toEqual({ joined: "eins", splitted: "eins" });
+	});
 
+	describe("single digit numbers", () => {
 		Object.entries(ones).forEach(([number, text]) => {
-			// avoid testing 1, since it's being tested just above
 			if (number === "1") return;
-			it(`converts ${number} to ${text}`, () => {
-				expect(numberToText(Number(number))).toBe(text);
+			it(`converts ${number}`, () => {
+				expect(numberToText(Number(number))).toEqual({ joined: text, splitted: text });
 			});
 		});
 	});
 
 	describe("numbers from 10 to 19", () => {
 		Object.entries(teens).forEach(([number, text]) => {
-			it(`converts ${number} to ${text}`, () => {
-				expect(numberToText(Number(number))).toBe(text);
+			it(`converts ${number}`, () => {
+				expect(numberToText(Number(number))).toEqual({ joined: text, splitted: text });
 			});
 		});
 	});
 
-	describe("multiples of 10 greater than 10 (20, 30, ...)", () => {
+	describe("multiples of 10 (20, 30, ...)", () => {
 		Object.entries(tens).forEach(([number, text]) => {
-			it(`converts ${number} to ${text}`, () => {
-				expect(numberToText(Number(number))).toBe(text);
+			it(`converts ${number}`, () => {
+				expect(numberToText(Number(number))).toEqual({ joined: text, splitted: text });
 			});
-		});
-	});
-
-	describe("powers of 10 greater than 10 (100, 1000, ...)", () => {
-		const cases: [number, string][] = [
-			[100, "ein hundert"],
-			[1_000, "ein tausend"],
-			[1_000_000, "eine million"],
-			[1_000_000_000, "eine milliarde"],
-			[1_000_000_000_000, "eine billion"],
-		];
-		it.each(cases)("converts %i to %s", (input, expected) => {
-			expect(numberToText(input)).toBe(expected);
 		});
 	});
 
 	describe("compound numbers", () => {
-		const cases: [number, string][] = [
-			[23, "drei und zwanzig"],
-			[109, "ein hundert neun"],
-			[119, "ein hundert neunzehn"],
-			[123, "ein hundert drei und zwanzig"],
-			[200, "zwei hundert"],
-			[223, "zwei hundert drei und zwanzig"],
-			[555, "fünf hundert fünf und fünfzig"],
-			[741, "sieben hundert ein und vierzig"],
-			[1234, "ein tausend zwei hundert vier und dreißig"],
-			[2_000, "zwei tausend"],
-			[10_000, "zehn tausend"],
-			[19_000, "neunzehn tausend"],
-			[1_001_000, "eine million ein tausend"],
-			[2_000_000, "zwei millionen"],
-			[2_500_000, "zwei millionen fünf hundert tausend"],
-			[3_000_000_000, "drei milliarden"],
+		const cases: [number, { joined: string; splitted: string }][] = [
+			[23, { joined: "dreiundzwanzig", splitted: "drei und zwanzig" }],
+			[109, { joined: "einhundertneun", splitted: "ein hundert neun" }],
+			[119, { joined: "einhundertneunzehn", splitted: "ein hundert neunzehn" }],
+			[123, { joined: "einhundertdreiundzwanzig", splitted: "ein hundert drei und zwanzig" }],
+			[200, { joined: "zweihundert", splitted: "zwei hundert" }],
+			[223, { joined: "zweihundertdreiundzwanzig", splitted: "zwei hundert drei und zwanzig" }],
+			[555, { joined: "fünfhundertfünfundfünfzig", splitted: "fünf hundert fünf und fünfzig" }],
+			[741, { joined: "siebenhunderteinundvierzig", splitted: "sieben hundert ein und vierzig" }],
+			[1_000, { joined: "eintausend", splitted: "ein tausend" }],
+			[1_234, { joined: "eintausendzweihundertvierunddreißig", splitted: "ein tausend zwei hundert vier und dreißig" }],
+			[2_000, { joined: "zweitausend", splitted: "zwei tausend" }],
+			[10_000, { joined: "zehntausend", splitted: "zehn tausend" }],
+			[19_000, { joined: "neunzehntausend", splitted: "neunzehn tausend" }],
+			[500_000, { joined: "fünfhunderttausend", splitted: "fünf hundert tausend" }],
+			[1_000_000, { joined: "eine million", splitted: "eine million" }],
+			[1_001_000, { joined: "eine million eintausend", splitted: "eine million ein tausend" }],
+			[2_000_000, { joined: "zwei millionen", splitted: "zwei millionen" }],
+			[2_500_000, { joined: "zwei millionen fünfhunderttausend", splitted: "zwei millionen fünf hundert tausend" }],
+			[1_000_023, { joined: "eine million dreiundzwanzig", splitted: "eine million drei und zwanzig" }],
+			[1_000_000_023, { joined: "eine milliarde dreiundzwanzig", splitted: "eine milliarde drei und zwanzig" }],
+			[1_000_000_000, { joined: "eine milliarde", splitted: "eine milliarde" }],
+			[3_000_000_000, { joined: "drei milliarden", splitted: "drei milliarden" }],
+			[1_000_000_000_000, { joined: "eine billion", splitted: "eine billion" }],
+			[1_234_567, { joined: "eine million zweihundertvierunddreißigtausendfünfhundertsiebenundsechzig", splitted: "eine million zwei hundert vier und dreißig tausend fünf hundert sieben und sechzig" }],
 		];
 
-		it.each(cases)("converts %i to %s", (input, expected) => {
-			expect(numberToText(input)).toBe(expected);
+		it.each(cases)("converts %i", (input, expected) => {
+			expect(numberToText(input)).toEqual(expected);
 		});
 	});
 });

--- a/src/core/numberToText/numberToText.ts
+++ b/src/core/numberToText/numberToText.ts
@@ -1,15 +1,15 @@
 import { ones, teens, tens, scales } from "./data.js";
 
 /**
- * Decomposes a number into its place values, from smallest 
+ * Decomposes a number into its place values, from smallest
  * to largest.
- * 
+ *
  * Digits with a value of zero are omitted, so the array length
  * does not necessarily correspond to the number of digits.
- * 
+ *
  * @param number - The number to decompose
  * @returns An array of place values
- * 
+ *
  * @example
  * getPlaceValues(0) // -> [0] (special case for zero)
  * getPlaceValues(1) // -> [1]
@@ -26,7 +26,7 @@ export function getPlaceValues(number: number): number[] {
 	const result = [];
 	let place = 1;
 	while (number > 0) {
-		// `% 10` extracts the last digit, `* place` gives it 
+		// `% 10` extracts the last digit, `* place` gives it
 		// its positional value
 		// e.g. for 123 at place 10: (12 % 10) * 10 = 20
 		const digit = (number % 10) * place;
@@ -43,20 +43,20 @@ export function getPlaceValues(number: number): number[] {
 
 /**
  * Returns the scale for a given number.
- * 
+ *
  * The function is used only on numbers `>= 100`.
- * 
- * The scale of a number is the largest scale value (hundert, 
+ *
+ * The scale of a number is the largest scale value (hundert,
  * tausend, million…) that is less than or equal to the number.
- * 
- * The scale will be used later to express the number as a 
- * multiplier of that scale. 
- * E.g. `300_000` has scale `1_000` and multiplier `300`. 
+ *
+ * The scale will be used later to express the number as a
+ * multiplier of that scale.
+ * E.g. `300_000` has scale `1_000` and multiplier `300`.
  * In turn, `300` has scale `100` and multiplier `3`.
- * 
+ *
  * @param number - The number whose scale we want to get
  * @returns The scale of the number
- * 
+ *
  * @example
  * getScale(100) // -> 100
  * getScale(1_000) // -> 1_000
@@ -79,10 +79,10 @@ export function getScale(number: number): number {
  * Given an array of numbers >= 100, groups them by their scale
  * (100, 1_000, 1_000_000...) and returns an array of [scale, values]
  * pairs, sorted from largest to smallest scale.
- * 
+ *
  * @param values - Array of numbers `>= 100`
  * @returns Array of numbers grouped by scale
- * 
+ *
  * @example
  * groupByScale([3_000, 100_000]) // -> [[1_000, [3_000, 100_000]]]
  * groupByScale([3_000, 2_000_000]) // -> [[1_000_000, [2_000_000]], [1_000, [3_000]]]
@@ -109,23 +109,25 @@ export function groupByScale(values: number[]): [number, number[]][] {
 
 /**
  * Given an array of values grouped by scale, converts each group
- * to its German word representation and returns them joined by spaces.
- * 
+ * to its German word representation and returns a single string.
+ *
  * Handles singular/plural and feminine forms for scale words
- * (e.g. "ein hundert", "eine million", "zwei millionen"). 
- * For compound multipliers, delegates to `numberToText` recursively.
- * 
- * @param groupedValues - Array of [scale, values] pairs, 
+ * (e.g. "ein tausend", "eine million", "zwei millionen").
+ * For compound multipliers, delegates to `numberToTextFormat` recursively.
+ *
+ * @param groupedValues - Array of [scale, values] pairs,
  * sorted from largest to smallest scale
- * @returns German words for the scaled values, joined by spaces
- * 
+ * @param format - "splitted" uses spaces, "joined" omits spaces below million
+ * @returns German words for the scaled values
+ *
  * @example
- * scaledValuesToWords([[1_000, [2_000]]]) // -> "zwei tausend"
- * scaledValuesToWords([[1_000_000, [2_000_000]], [1_000, [3_000]]]) // -> "zwei millionen drei tausend"
+ * scaledValuesToWords([[1_000, [2_000]]], "splitted") // -> "zwei tausend"
+ * scaledValuesToWords([[1_000, [2_000]]], "joined") // -> "zweitausend"
  */
 
 export function scaledValuesToWords(
 	groupedValues: [number, number[]][],
+	format: "joined" | "splitted" = "splitted",
 ): string {
 	const words: string[] = [];
 
@@ -134,17 +136,21 @@ export function scaledValuesToWords(
 		const multiplier = sum / scale;
 		const isMultiplierSingular = multiplier === 1;
 		const isScaleFeminine = scales[scale].feminine;
-		const scaleWord = isMultiplierSingular ? scales[scale].singular : scales[scale].plural;
+		const scaleWord = isMultiplierSingular
+			? scales[scale].singular
+			: scales[scale].plural;
 		let multiplierWord = "";
 		if (isMultiplierSingular) {
 			multiplierWord = isScaleFeminine ? "eine" : "ein";
 		} else {
-			multiplierWord = numberToText(multiplier);
+			multiplierWord = numberToTextFormat(multiplier, format);
 		}
-		words.push(`${multiplierWord} ${scaleWord}`);
+		const separator = format === "joined" && scale < 1_000_000 ? "" : " ";
+		const trailingSeparator = format === "joined" && scale >= 1_000_000 ? " " : "";
+		words.push(`${multiplierWord}${separator}${scaleWord}${trailingSeparator}`);
 	}
 
-	return words.join(" ");
+	return words.join(format === "joined" ? "" : " ").trim();
 }
 
 /**
@@ -152,17 +158,21 @@ export function scaledValuesToWords(
  * German word representation.
  *
  * @param values - Array of place values < 100, from smallest to largest
+ * @param format - "splitted" uses spaces, "joined" omits spaces
  * @returns German word or phrase for the given values
  *
  * @example
  * unscaledValuesToWords([1]) // -> "ein"
  * unscaledValuesToWords([9]) // -> "neun"
  * unscaledValuesToWords([10]) // -> "zehn"
- * unscaledValuesToWords([3, 20]) // -> "drei und zwanzig"
- * unscaledValuesToWords([9, 90]) // -> "neun und neunzig"
+ * unscaledValuesToWords([3, 20], "splitted") // -> "drei und zwanzig"
+ * unscaledValuesToWords([3, 20], "joined") // -> "dreiundzwanzig"
  */
 
-export function unscaledValuesToWords(values: number[]): string {
+export function unscaledValuesToWords(
+	values: number[],
+	format: "joined" | "splitted" = "splitted",
+): string {
 	if (values.length === 0) return "";
 
 	if (!values[1]) {
@@ -175,30 +185,18 @@ export function unscaledValuesToWords(values: number[]): string {
 	if (tenths === 0) return ones[units];
 	if (tenths < 20) return teens[tenths + units];
 
-	return `${ones[units]} und ${tens[tenths]}`;
+	const und = format === "joined" ? "und" : " und ";
+	return `${ones[units]}${und}${tens[tenths]}`;
 }
 
 /**
- * Core of the app. Takes a number and orchestrates the full pipeline
- * to convert it into its German word representation.
- *
- * Handles special cases for 0 ("null") and 1 ("eins"). For larger numbers,
- * splits place values into scaled (>= 100) and unscaled (< 100) groups,
- * converts them separately and combines the results. Recurses on compound
- * multipliers via `scaledValuesToWords`.
- *
- * @param number - The number to convert
- * @returns German word representation of the number
- *
- * @example
- * numberToText(0) // -> "null"
- * numberToText(1) // -> "eins"
- * numberToText(23) // -> "drei und zwanzig"
- * numberToText(1_234) // -> "ein tausend zwei hundert vier und dreißig"
- * numberToText(1_000_000) // -> "eine million"
+ * Internal implementation of numberToText with a format parameter.
  */
 
-export function numberToText(number: number): string {
+function numberToTextFormat(
+	number: number,
+	format: "joined" | "splitted",
+): string {
 	if (number === 0) return "null";
 	if (number === 1) return "eins";
 
@@ -208,14 +206,39 @@ export function numberToText(number: number): string {
 
 	const groupedScaledValues = groupByScale(scaledValues);
 
-	const scaledWords = scaledValuesToWords(groupedScaledValues);
-	const unscaledWords = unscaledValuesToWords(unscaledValues);
+	const scaledWords = scaledValuesToWords(groupedScaledValues, format);
+	const unscaledWords = unscaledValuesToWords(unscaledValues, format);
 
 	if (scaledWords && unscaledWords) {
-		return scaledWords + " " + unscaledWords;
+		const lastScale = groupedScaledValues.at(-1)?.[0] ?? 0;
+		const separator = format === "splitted" || lastScale >= 1_000_000 ? " " : "";
+		return `${scaledWords}${separator}${unscaledWords}`;
 	} else if (unscaledWords) {
 		return unscaledWords;
 	} else {
 		return scaledWords;
 	}
+}
+
+/**
+ * app. Takes a number and converts it into its German word 
+ * representation, returning both joined and splitted formats.
+ *
+ * @param number - The number to convert
+ * @returns Object with `joined` (grammatically correct) and `splitted` (spaced) 
+ * German representations
+ *
+ * @example
+ * numberToText(0) // -> { joined: "null", splitted: "null" }
+ * numberToText(1) // -> { joined: "eins", splitted: "eins" }
+ * numberToText(23) // -> { joined: "dreiundzwanzig", splitted: "drei und zwanzig" }
+ * numberToText(1_234) // -> { joined: "eintausendzweihundertvierunddreißig", splitted: "ein tausend zwei hundert vier und dreißig" }
+ * numberToText(1_000_000) // -> { joined: "eine million", splitted: "eine million" }
+ */
+
+export function numberToText(number: number): { joined: string; splitted: string } {
+	return {
+		joined: numberToTextFormat(number, "joined"),
+		splitted: numberToTextFormat(number, "splitted"),
+	};
 }


### PR DESCRIPTION
Numbers can now be expressed in two formats:
- joined (e.g. `einhundertdreiundzwanzig`), linguistically correct German form, default CLI output
- splitted (e.g. `ein hundert drei und zwanzig`), intended for future TTS use

`numberToText` now returns `{ joined, splitted }` instead of a string.

CLI defaults to joined, with `--splitted` flag to switch format.
