### PR TITLE
feat: add spelling format toggle to web app

### DIFF
--- a/src/web/components/NumberInput.tsx
+++ b/src/web/components/NumberInput.tsx
@@ -4,13 +4,15 @@ import { Button } from "@/web/components/ui/button";
 import { Input } from "@/web/components/ui/input";
 
 type NumberInputProps = {
-  setConversionResult: React.Dispatch<React.SetStateAction<{
-    number: number | null;
-    spelled: string | null;
-  }>>;
-}
+	setConversionResult: React.Dispatch<
+		React.SetStateAction<{
+			number: number | null;
+			spelled: { joined: string; splitted: string } | null;
+		}>
+	>;
+};
 
-export default function NumberInput({setConversionResult}: NumberInputProps) {
+export default function NumberInput({ setConversionResult }: NumberInputProps) {
 	const [value, setValue] = useState<string>("");
 
 	function handleSubmit(event: React.SubmitEvent) {
@@ -19,7 +21,7 @@ export default function NumberInput({setConversionResult}: NumberInputProps) {
 		const numberValue = Number(value);
 		const newOutput = {
 			number: numberValue,
-			spelled: numberToText(numberValue).joined,
+			spelled: numberToText(numberValue),
 		};
 		setConversionResult(newOutput);
 		setValue("");

--- a/src/web/components/NumberToSpelling.tsx
+++ b/src/web/components/NumberToSpelling.tsx
@@ -3,10 +3,11 @@ import { useState } from "react";
 import NumberInput from "./NumberInput.js";
 import OutputDisplay from "./OutputDisplay.js";
 
+
 export default function NumberToSpelling() {
 	const [conversionResult, setConversionResult] = useState<{
 		number: number | null;
-		spelled: string | null;
+		spelled: {joined: string, splitted: string} | null;
 	}>({ number: null, spelled: null });
 
 	return (

--- a/src/web/components/OutputDisplay.tsx
+++ b/src/web/components/OutputDisplay.tsx
@@ -1,20 +1,30 @@
+import { Switch } from "@/web/components/ui/switch";
+import { useState } from "react";
+
+type SpellingFormat = "joined" | "splitted";
+
 type OutputDisplayProps = {
 	conversionResult: {
 		number: number | null;
-		spelled: string | null;
+		spelled: { joined: string; splitted: string } | null;
 	};
 };
 
 export default function OutputDisplay({
 	conversionResult,
 }: OutputDisplayProps) {
+	const [spellingFormat, setSpellingFormat] =
+		useState<SpellingFormat>("joined");
+	const toggleFormat = () =>
+		setSpellingFormat((format) =>
+			format === "joined" ? "splitted" : "joined",
+		);
+	const displaySpelling = conversionResult.spelled?.[spellingFormat] ?? "-";
+
 	return (
 		<div className="rounded-xl border border-border bg-muted/30 min-h-[120px]">
 			<div className="flex flex-col gap-1 p-4 border-b border-border">
-				<label
-					htmlFor="input-number"
-					className="text-muted-foreground"
-				>
+				<label htmlFor="input-number" className="text-muted-foreground">
 					Your input
 				</label>
 				<output
@@ -26,20 +36,37 @@ export default function OutputDisplay({
 					)}
 				</output>
 			</div>
-			<div className="flex flex-col gap-1 p-4">
-				<label
-					htmlFor="spelled-out-number"
-					className="text-muted-foreground"
-				>
-					German spelling
-				</label>
-				<output
-					id="spelled-out-number"
-					className={`text-2xl ${!conversionResult.spelled ? "text-muted-foreground" : ""}`}
-					lang="de"
-				>
-					{conversionResult.spelled ?? "-"}
-				</output>
+			<div className="flex flex-col gap-1 pt-4 px-4 pb-4">
+				<div className="flex gap-3 justify-between">
+					<label
+						htmlFor="spelled-out-number"
+						className="text-muted-foreground"
+					>
+						German spelling
+					</label>
+
+					<div className="flex items-center gap-2 text-sm">
+						<label htmlFor="spelling-format" className="sr-only">
+							Spelling format
+						</label>
+						<span className={conversionResult.spelled && spellingFormat === "joined" ? "text-yellow-300 font-semibold" : "text-muted-foreground"}>joined</span>
+						<Switch
+							id="spelling-format"
+							disabled={!conversionResult.spelled}
+							onCheckedChange={toggleFormat}
+							/>
+						<span className={conversionResult.spelled && spellingFormat === "splitted" ? "text-yellow-300 font-semibold" : "text-muted-foreground"}>splitted</span>
+					</div>
+				</div>
+				<div className="overflow-x-auto pb-4">
+					<output
+						id="spelled-out-number"
+						className={`text-2xl ${!conversionResult.spelled ? "text-muted-foreground" : ""}`}
+						lang="de"
+					>
+						{displaySpelling}
+					</output>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/web/components/ui/switch.tsx
+++ b/src/web/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/web/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -119,6 +119,8 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    scrollbar-color: oklch(0.905 0.182 98.111) transparent;
+    scrollbar-width: thin;
     }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
Adds a toggle to switch between joined and splitted spelling formats in the web app.

- joined (e.g. `einhundertdreiundzwanzig`) is shown by default
- splitted (e.g. `ein hundert drei und zwanzig`) available via toggle
- Toggle is disabled until a number is converted
- Long words scroll horizontally instead of breaking